### PR TITLE
Feat memory buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Calculator v1
+## Introduction
+- This is a simple calculator that is written in x86 assembly! My first mini-project to practice assembly.
+- Developed 2025-06-08 - 2025-06-13
+- It can only handle single digit imput and output
+    - e.g., 4+5 will work
+    - e.g., 5+6 will not work since the output is 2 digits
+
+## Packages
+- To run the app make sure you have the following packages:
+    1. 
+
+- For Debian/ Ubuntu-based systems:
+```
+sudo apt update
+sudo apt install nasm gcc make gdb
+``` 
+
+- For Arch Linux:
+```
+sudo pacman -S nasm base-devel gdb
+```
+
+## Running the app
+- This app should be ran on x86 architecture. It will not run on ARM machines (e.g., Silicon Macs)
+- To run the app simply:
+    1. Type `make` to assemble the source code in the terminal (make sure that you are in the correct directory)
+    2. Type `make run` to run the program
+    3. To debug the program using GDB use `make debug`

--- a/src/main.asm
+++ b/src/main.asm
@@ -212,6 +212,7 @@ error_print:
     ; MOV edx, 100       ; read up to 100 bytes
     ; INT 80h
     ; ; We don’t care about result
+    CALL flush_stdin
 
     CALL red_error_message_colour_on
 
@@ -240,3 +241,16 @@ exit:
     INT 80h
 
 
+flush_stdin:
+flush_loop:
+    MOV eax,3
+    MOV ebx,0
+    MOV ecx,memory_buffer
+    MOV edx,1
+    INT 80h
+    CMP eax,0
+    JE flush_end
+    CMP BYTE [memory_buffer], 0x0A
+    JNE flush_loop
+flush_end:
+    RET

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,7 +16,7 @@ section .data
     output_msg        DB         'Output: ', 0x00
     output_msg_len    EQU        $ - output_msg
 
-    error_text        DB         '2 digits max!', 0x00
+    error_text        DB         '1 digits max!', 0x00
     error_text_length EQU        $ - error_text
 
     end_print         DB         0xA, 0x00
@@ -24,10 +24,7 @@ section .data
 
 
 section .bss
-    num1     RESB 2
-    num2     RESB 2
-    opp      RESB 2
-    res      RESB 2
+    memory_buffer RESB 100
 
 section .text
     
@@ -51,9 +48,13 @@ _start:
     ; Listen for 1st number
     MOV eax,3 ; sys_read
     MOV ebx,0 ; file descriptor 0 => stdin
-    MOV ecx,num1
-    MOV edx,2
+    MOV ecx,memory_buffer
+    MOV edx,10
     INT 80h
+
+    ; Calculator for 1 digit max => 1 character + newline character 
+    CMP BYTE [memory_buffer + 0x01], 0x0A ; Is a newline a 2nd character? 
+    JNE error_print
 
     ; Print message 3
     MOV eax,4
@@ -65,9 +66,13 @@ _start:
     ; Listen for 2nd number
     MOV eax,3
     MOV ebx,0
-    MOV ecx,num2
-    MOV edx,2
+    MOV ecx,memory_buffer + 0x02
+    MOV edx,10
     INT 80h
+
+    ; Calculator for 1 digit max => 1 character + newline character 
+    CMP BYTE [memory_buffer + 0x03], 0x0A ; Is a newline a 2nd character? 
+    JNE error_print
 
     ; Print message 4
     MOV eax,4
@@ -79,16 +84,20 @@ _start:
     ; Listen for the opperation
     MOV eax,3
     MOV ebx,0
-    MOV ecx,opp
+    MOV ecx,memory_buffer + 0x04
     MOV edx,2
     INT 80h
 
+    ; Calculator for 1 digit max => 1 character + newline character 
+    CMP BYTE [memory_buffer + 0x05], 0x0A ; Is a newline a 2nd character? 
+    JNE error_print
+
     ; Identify the operration to perform
-    MOV cl,[opp]
+    MOV cl,[memory_buffer + 0x04]
     SUB cl,'0'
-    MOV al,[num1]       ; e.g. '4' = 0x3
-    SUB al,'0'          ; 0x34 - 0x30 = 0x04
-    MOV bl,[num2]
+    MOV al,[memory_buffer]         ; e.g. '4' = 0x3
+    SUB al,'0'                     ; 0x34 - 0x30 = 0x04
+    MOV bl,[memory_buffer + 0x02]
     SUB bl,'0'
 
     CMP cl,1
@@ -104,26 +113,26 @@ _start:
 addition:
     ADD al,bl
     ADD al,'0'  ; Convert to ASCII
-    MOV [res],al
+    MOV [memory_buffer + 0x06],al
     JMP print_result
 
 subtract:
     SUB al,bl
     ADD al,'0'
-    MOV [res],al
+    MOV [memory_buffer + 0x06],al
     JMP print_result
 
 multiply:
     MUL bl
     ADD al, '0'
-    MOV [res],al
+    MOV [memory_buffer + 0x06],al
     JMP print_result
 
 divide:
     MOV ah,0
     DIV bl
     ADD al, '0'
-    MOV [res],al
+    MOV [memory_buffer + 0x06],al
     JMP print_result
 
 print_result:
@@ -136,17 +145,27 @@ print_result:
 
     MOV eax,4
     MOV ebx,1
-    MOV ecx,res
+    LEA ecx,[memory_buffer + 0x06]
     MOV edx,1
     INT 80h
 
     JMP exit
 
 error_print:
+    ; Flush stdin
+    MOV eax, 3         ; sys_read
+    MOV ebx, 0         ; stdin
+    MOV ecx, memory_buffer
+    MOV edx, 100       ; read up to 100 bytes
+    INT 80h
+    ; We don’t care about result
+
+    ; Print the error message
     MOV eax,4
     MOV ebx,1
     MOV ecx,error_text
     MOV edx,error_text_length
+    INT 80h
     JMP exit
 
 exit:

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,7 +16,7 @@ section .data
     output_msg        DB         'Output: ', 0x00
     output_msg_len    EQU        $ - output_msg
 
-    error_text        DB         '1 digits max!', 0x00
+    error_text        DB         'Error: This calculator allows 1 digit max!', 0x00
     error_text_length EQU        $ - error_text
 
     end_print         DB         0xA, 0x00
@@ -52,7 +52,11 @@ _start:
     MOV edx,10
     INT 80h
 
-    ; Calculator for 1 digit max => 1 character + newline character 
+    ; Make sure user didn't press enter by mistake when the program started to run
+    CMP eax, 0x1 ; Was only one character entered 
+    JE error_print
+    
+    ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x01], 0x0A ; Is a newline a 2nd character? 
     JNE error_print
 
@@ -70,7 +74,11 @@ _start:
     MOV edx,10
     INT 80h
 
-    ; Calculator for 1 digit max => 1 character + newline character 
+    ; Make sure user didn't press enter by mistake when the program started to run
+    CMP eax, 0x1 ; Is a newline a 1st character? 
+    JE error_print
+    
+    ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x03], 0x0A ; Is a newline a 2nd character? 
     JNE error_print
 
@@ -88,7 +96,11 @@ _start:
     MOV edx,2
     INT 80h
 
-    ; Calculator for 1 digit max => 1 character + newline character 
+    ; Make sure user didn't press enter by mistake when the program started to run
+    CMP eax, 0x1 ; Is a newline a 1st character? 
+    JE error_print
+    
+    ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x05], 0x0A ; Is a newline a 2nd character? 
     JNE error_print
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -19,16 +19,17 @@ section .data
     error_text        DB         'ERROR: one digit max O_o', 0x00
     error_text_length EQU        $ - error_text
 
-    error_enter_typed DB         'ERROR: no number given -_-'
-    error_enter_typed_len EQU    $ - error_enter_typed
+    error_no_number   DB         'ERROR: no number given -_-'
+    error_no_num_len  EQU        $ - error_no_number
 
     end_print         DB         0xA, 0x00
     end_print_len     EQU        $ - end_print
 
     red_start         DB         0x1B, '[31m', 0 
-    red_start_len     EQU        $ - red_start       
-    reset_colour       DB         0x1B, '[0m', 0
-    reset_colour_len   EQU        $ - reset_colour
+    red_start_len     EQU        $ - red_start     
+
+    reset_colour      DB         0x1B, '[0m', 0
+    reset_colour_len  EQU        $ - reset_colour
 
 
 section .bss
@@ -178,6 +179,7 @@ red_error_message_colour_on:
     MOV ecx,red_start
     MOV edx,red_start_len
     INT 80h
+    RET
 
 red_error_message_colour_off:
 ; Set red colour to the message
@@ -186,6 +188,7 @@ red_error_message_colour_off:
     MOV ecx,reset_colour
     MOV edx,reset_colour_len
     INT 80h
+    RET
 
 error_print_enter_pressed:
     ; Text for when user presses enter instead of a number
@@ -193,8 +196,8 @@ error_print_enter_pressed:
 
     MOV eax,4
     MOV ebx,1
-    MOV ecx,error_enter_typed
-    MOV edx,error_enter_typed_len
+    MOV ecx,error_no_number
+    MOV edx,error_no_num_len
     INT 80h
 
     CALL red_error_message_colour_off

--- a/src/main.asm
+++ b/src/main.asm
@@ -172,8 +172,8 @@ print_result:
 
     JMP exit
 
-red_error_message_colour_on:
 ; Set red colour to the message
+red_error_message_colour_on:
     MOV eax,4
     MOV ebx,1
     MOV ecx,red_start
@@ -181,8 +181,8 @@ red_error_message_colour_on:
     INT 80h
     RET
 
-red_error_message_colour_off:
 ; Set red colour to the message
+red_error_message_colour_off:
     MOV eax,4
     MOV ebx,1
     MOV ecx,reset_colour

--- a/src/main.asm
+++ b/src/main.asm
@@ -25,6 +25,11 @@ section .data
     end_print         DB         0xA, 0x00
     end_print_len     EQU        $ - end_print
 
+    red_start         DB         0x1B, '[31m', 0 
+    red_start_len     EQU        $ - red_start       
+    reset_colour       DB         0x1B, '[0m', 0
+    reset_colour_len   EQU        $ - reset_colour
+
 
 section .bss
     memory_buffer RESB 100
@@ -166,13 +171,34 @@ print_result:
 
     JMP exit
 
+red_error_message_colour_on:
+; Set red colour to the message
+    MOV eax,4
+    MOV ebx,1
+    MOV ecx,red_start
+    MOV edx,red_start_len
+    INT 80h
+
+red_error_message_colour_off:
+; Set red colour to the message
+    MOV eax,4
+    MOV ebx,1
+    MOV ecx,reset_colour
+    MOV edx,reset_colour_len
+    INT 80h
+
 error_print_enter_pressed:
     ; Text for when user presses enter instead of a number
+    CALL red_error_message_colour_on
+
     MOV eax,4
     MOV ebx,1
     MOV ecx,error_enter_typed
     MOV edx,error_enter_typed_len
     INT 80h
+
+    CALL red_error_message_colour_off
+
     JMP exit
 
 error_print:
@@ -184,12 +210,17 @@ error_print:
     ; INT 80h
     ; ; We don’t care about result
 
+    CALL red_error_message_colour_on
+
     ; Print the error message
     MOV eax,4
     MOV ebx,1
     MOV ecx,error_text
     MOV edx,error_text_length
     INT 80h
+
+    CALL red_error_message_colour_off
+
     JMP exit
 
 exit:

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,8 +16,11 @@ section .data
     output_msg        DB         'Output: ', 0x00
     output_msg_len    EQU        $ - output_msg
 
-    error_text        DB         'Error: This calculator allows 1 digit max!', 0x00
+    error_text        DB         'ERROR: one digit max O_o', 0x00
     error_text_length EQU        $ - error_text
+
+    error_enter_typed DB         'ERROR: no number given -_-'
+    error_enter_typed_len EQU    $ - error_enter_typed
 
     end_print         DB         0xA, 0x00
     end_print_len     EQU        $ - end_print
@@ -54,7 +57,7 @@ _start:
 
     ; Make sure user didn't press enter by mistake when the program started to run
     CMP eax, 0x1 ; Was only one character entered 
-    JE error_print
+    JE error_print_enter_pressed
     
     ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x01], 0x0A ; Is a newline a 2nd character? 
@@ -76,7 +79,7 @@ _start:
 
     ; Make sure user didn't press enter by mistake when the program started to run
     CMP eax, 0x1 ; Is a newline a 1st character? 
-    JE error_print
+    JE error_print_enter_pressed
     
     ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x03], 0x0A ; Is a newline a 2nd character? 
@@ -98,7 +101,7 @@ _start:
 
     ; Make sure user didn't press enter by mistake when the program started to run
     CMP eax, 0x1 ; Is a newline a 1st character? 
-    JE error_print
+    JE error_print_enter_pressed
     
     ; Check to make sure that only one digit was typed 
     CMP BYTE [memory_buffer + 0x05], 0x0A ; Is a newline a 2nd character? 
@@ -163,14 +166,23 @@ print_result:
 
     JMP exit
 
-error_print:
-    ; Flush stdin
-    MOV eax, 3         ; sys_read
-    MOV ebx, 0         ; stdin
-    MOV ecx, memory_buffer
-    MOV edx, 100       ; read up to 100 bytes
+error_print_enter_pressed:
+    ; Text for when user presses enter instead of a number
+    MOV eax,4
+    MOV ebx,1
+    MOV ecx,error_enter_typed
+    MOV edx,error_enter_typed_len
     INT 80h
-    ; We don’t care about result
+    JMP exit
+
+error_print:
+    ; ; Flush stdin
+    ; MOV eax, 3         ; sys_read
+    ; MOV ebx, 0         ; stdin
+    ; MOV ecx, memory_buffer
+    ; MOV edx, 100       ; read up to 100 bytes
+    ; INT 80h
+    ; ; We don’t care about result
 
     ; Print the error message
     MOV eax,4

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,0 @@
-- If a user enters a single number, then a new line appears and a user can add another nuber
-- Create a heap to dynamically allocate memory
-
-- Reserve memory vs push onto the stack vs store in registers?


### PR DESCRIPTION
v1.1
- Create a memory buffer of 100 bytes so that program would not crash if a user enters more than 1 digit
- Refactor error message texts (and colour  them in red)
- Make sure if a user adds a lot of numbers (e.g., 9091931923 they do not overflow into the shell once program exits). This is done via flushing stdin